### PR TITLE
Fix project website links

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -23,7 +23,7 @@ You can reach us at the email `e0970391@u.nus.edu`
 
 <img src="images/limyifei1513.png" width="200px">
 
-[[github](http://github.com/limyifei)] 
+[[github](https://github.com/limyifei1513)] 
 [[portfolio](team/limyifei1513.md)]
 
 * Role: Deliverables and deadlines

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2526S2-CS2103-F09-1/tp"
 github_icon: "images/github-icon.png"
 
 plugins:


### PR DESCRIPTION
Close #74 

- Fix Yi Fei's GitHub link (in AboutUs.md)
- Change repository link (at top-right hand corner of the project website) from AB3 to EduConnect