### PR TITLE
Update UG to include the Copy command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -166,13 +166,13 @@ Copy a specified field of a person from the address book to the user clipboard.
 Format: `copy ID field`
 
 * Copies the `field` data for the person with the specified `ID` to the user clipboard.
-* Possible fields include `/n` for name, `/p` for phone number, and `/a` for address
+* Possible fields include `n/` for name, `p/` for phone number, and `a/` for address
 * If the person's field is empty, then nothing will be copy to the clipboard.
 
 Examples:
-* `copy 6 n/` copy the person with `ID` 6 name to the clipboard.
-* `copy 7 p/` copy the person with `ID` 7 phone number to the clipboard.
-* `copy 9 a/` copy the person with `ID` 9 address to the clipboard.
+* `copy 6 n/` copy the name of the person with `ID` 6 to the clipboard.
+* `copy 7 p/` copy the phone number of the person with `ID` 7 to the clipboard.
+* `copy 9 a/` copy the address of the person with `ID` 9 to the clipboard .
 * `copy 1 p/` will fail if `ID` 1 is not found or the phone number field of the person with `ID` 1 is empty. 
 
 ### Clearing all entries : `clear`


### PR DESCRIPTION
close #136 

Update UG to now include the copy command to give the user an easy understanding of how to use the command. The instructions and examples of how to use the copy command are now shown in the user guide.