### PR TITLE
feat: Edit UI to PapayaWhip theme

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -21,6 +21,9 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String CSS_CLASS_MISSING_FIELD = "missing-field";
 
+    private static final String PHONE_ICON = "\uD83D\uDCDE";
+    private static final String ADDRESS_ICON = "\uD83C\uDFE0";
+
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
      * As a consequence, UI elements' variable names cannot be set to such keywords
@@ -77,10 +80,10 @@ public class PersonCard extends UiPart<Region> {
         String phoneNumber = person.getPhone().value;
 
         if (phoneNumber.isEmpty()) {
-            phoneLabel.setText(MESSAGE_MISSING_PHONE_NUMBER);
+            phoneLabel.setText(PHONE_ICON + " " + MESSAGE_MISSING_PHONE_NUMBER);
             addCssClass(phoneLabel, CSS_CLASS_MISSING_FIELD);
         } else {
-            phoneLabel.setText(phoneNumber);
+            phoneLabel.setText(PHONE_ICON + " " + phoneNumber);
         }
     }
 
@@ -88,10 +91,10 @@ public class PersonCard extends UiPart<Region> {
         String address = person.getAddress().value;
 
         if (address.isEmpty()) {
-            addressLabel.setText(MESSAGE_MISSING_ADDRESS);
+            addressLabel.setText(ADDRESS_ICON + " " + MESSAGE_MISSING_ADDRESS);
             addCssClass(addressLabel, CSS_CLASS_MISSING_FIELD);
         } else {
-            addressLabel.setText(address);
+            addressLabel.setText(ADDRESS_ICON + " " + address);
         }
     }
 

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -65,7 +65,7 @@ public class UiManager implements Ui {
     private static void showAlertDialogAndWait(Stage owner, AlertType type, String title, String headerText,
                                                String contentText) {
         final Alert alert = new Alert(type);
-        alert.getDialogPane().getStylesheets().add("view/DarkTheme.css");
+        alert.getDialogPane().getStylesheets().add("view/Theme.css");
         alert.initOwner(owner);
         alert.setTitle(title);
         alert.setHeaderText(headerText);

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -5,7 +5,7 @@
 
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
-    -fx-background: #383838;
+    -fx-background: derive(#FFEFD5, -10%);
 }
 
 .tag-selector {

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,19 +1,19 @@
 #copyButton, #helpMessage {
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
 }
 
 #copyButton {
-    -fx-background-color: dimgray;
+    -fx-background-color: #C19A6B;
 }
 
 #copyButton:hover {
-    -fx-background-color: gray;
+    -fx-background-color: #D2B48C;
 }
 
 #copyButton:armed {
-    -fx-background-color: darkgray;
+    -fx-background-color: #A67B5B;
 }
 
 #helpMessageContainer {
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: derive(#FFEFD5, -10%);
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -3,26 +3,27 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="EduConnect" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
   <scene>
     <Scene>
       <stylesheets>
-        <URL value="@DarkTheme.css" />
+        <URL value="@Theme.css" />
         <URL value="@Extensions.css" />
       </stylesheets>
-
       <VBox>
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
@@ -32,6 +33,10 @@
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
           </Menu>
         </MenuBar>
+
+        <HBox fx:id="appHeader" styleClass="app-header" VBox.vgrow="NEVER" minHeight="80" alignment="CENTER_LEFT" spacing="10">
+          <Label text="EduConnect 📖" styleClass="app-header-label"/>
+        </HBox>
 
         <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
           <padding>

--- a/src/main/resources/view/Theme.css
+++ b/src/main/resources/view/Theme.css
@@ -1,31 +1,31 @@
 .background {
-    -fx-background-color: derive(#1d1d1d, 20%);
-    background-color: #383838; /* Used in the default.html file */
+    -fx-background-color: derive(#FFEFD5, -10%);
+    background-color: #FFEFD5; /* Used in the default.html file */
 }
 
 .label {
     -fx-font-size: 11pt;
     -fx-font-family: "Segoe UI Semibold";
-    -fx-text-fill: #555555;
+    -fx-text-fill: #5A4634;
     -fx-opacity: 0.9;
 }
 
 .label-bright {
     -fx-font-size: 11pt;
     -fx-font-family: "Segoe UI Semibold";
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
     -fx-opacity: 1;
 }
 
 .label-header {
     -fx-font-size: 32pt;
     -fx-font-family: "Segoe UI Light";
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
     -fx-opacity: 1;
 }
 
 .label.cell_small_label.missing-field {
-    -fx-text-fill: red;
+    -fx-text-fill: #C94C4C;
 }
 
 .text-field {
@@ -44,9 +44,9 @@
 }
 
 .table-view {
-    -fx-base: #1d1d1d;
-    -fx-control-inner-background: #1d1d1d;
-    -fx-background-color: #1d1d1d;
+    -fx-base: #FFEFD5;
+    -fx-control-inner-background: #FFF5E6;
+    -fx-background-color: #FFEFD5;
     -fx-table-cell-border-color: transparent;
     -fx-table-header-border-color: transparent;
     -fx-padding: 5;
@@ -63,7 +63,7 @@
     -fx-border-color:
         transparent
         transparent
-        derive(-fx-base, 80%)
+        derive(-fx-base, -30%)
         transparent;
     -fx-border-insets: 0 10 1 0;
 }
@@ -71,7 +71,7 @@
 .table-view .column-header .label {
     -fx-font-size: 20pt;
     -fx-font-family: "Segoe UI Light";
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
     -fx-alignment: center-left;
     -fx-opacity: 1;
 }
@@ -81,20 +81,20 @@
 }
 
 .split-pane:horizontal .split-pane-divider {
-    -fx-background-color: derive(#1d1d1d, 20%);
-    -fx-border-color: transparent transparent transparent #4d4d4d;
+    -fx-background-color: derive(#FFEFD5, -10%);
+    -fx-border-color: transparent transparent transparent #D2B48C;
 }
 
 .split-pane {
     -fx-border-radius: 1;
     -fx-border-width: 1;
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: derive(#FFEFD5, -10%);
 }
 
 .list-view {
     -fx-background-insets: 0;
     -fx-padding: 0;
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: derive(#FFEFD5, -10%);
 }
 
 .list-cell {
@@ -104,111 +104,132 @@
 }
 
 .list-cell:filled:even {
-    -fx-background-color: #3c3e3f;
+    -fx-background-color: #F5DEB3;
 }
 
 .list-cell:filled:odd {
-    -fx-background-color: #515658;
+    -fx-background-color: #EED5B7;
 }
 
 .list-cell:filled:selected {
-    -fx-background-color: #424d5f;
+    -fx-background-color: #D2B48C;
 }
 
 .list-cell:filled:selected #cardPane {
-    -fx-border-color: #3e7b91;
+    -fx-border-color: #C19A6B;
     -fx-border-width: 1;
 }
 
 .list-cell .label {
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
 }
 
 .cell_big_label {
     -fx-font-family: "Segoe UI Semibold";
     -fx-font-size: 16px;
-    -fx-text-fill: #010504;
+    -fx-text-fill: #3E2F1C;
 }
 
 .cell_small_label {
     -fx-font-family: "Segoe UI";
     -fx-font-size: 13px;
-    -fx-text-fill: #010504;
+    -fx-text-fill: #5A4634;
 }
 
 .stack-pane {
-     -fx-background-color: derive(#1d1d1d, 20%);
+     -fx-background-color: derive(#FFEFD5, -10%);
 }
 
 .pane-with-border {
-     -fx-background-color: derive(#1d1d1d, 20%);
-     -fx-border-color: derive(#1d1d1d, 10%);
+     -fx-background-color: derive(#FFEFD5, -10%);
+     -fx-border-color: derive(#FFEFD5, -20%);
      -fx-border-top-width: 1px;
 }
 
 .status-bar {
-    -fx-background-color: derive(#1d1d1d, 30%);
+    -fx-background-color: derive(#FFEFD5, -20%);
 }
 
 .result-display {
     -fx-background-color: transparent;
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
 }
 
 .result-display .label {
-    -fx-text-fill: black !important;
+    -fx-text-fill: #3E2F1C !important;
 }
 
 .status-bar .label {
     -fx-font-family: "Segoe UI Light";
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
     -fx-padding: 4px;
     -fx-pref-height: 30px;
 }
 
 .status-bar-with-border {
-    -fx-background-color: derive(#1d1d1d, 30%);
-    -fx-border-color: derive(#1d1d1d, 25%);
+    -fx-background-color: derive(#FFEFD5, -20%);
+    -fx-border-color: derive(#FFEFD5, -25%);
     -fx-border-width: 1px;
 }
 
 .status-bar-with-border .label {
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
 }
 
 .grid-pane {
-    -fx-background-color: derive(#1d1d1d, 30%);
-    -fx-border-color: derive(#1d1d1d, 30%);
+    -fx-background-color: derive(#FFEFD5, -20%);
+    -fx-border-color: derive(#FFEFD5, -20%);
     -fx-border-width: 1px;
 }
 
 .grid-pane .stack-pane {
-    -fx-background-color: derive(#1d1d1d, 30%);
+    -fx-background-color: derive(#FFEFD5, -20%);
 }
 
 .context-menu {
-    -fx-background-color: derive(#1d1d1d, 50%);
+    -fx-background-color: derive(#FFEFD5, -30%);
 }
 
 .context-menu .label {
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
 }
 
 .menu-bar {
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: derive(#FFEFD5, -10%);
 }
 
 .menu-bar .label {
     -fx-font-size: 14pt;
     -fx-font-family: "Segoe UI Light";
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
     -fx-opacity: 0.9;
 }
 
 .menu .left-container {
-    -fx-background-color: black;
+    -fx-background-color: #E6D3B3;
+}
+
+.menu-button:hover {
+    -fx-background-color: #C19A6B;
+}
+
+.menu-button:armed,
+.menu-button:showing {
+    -fx-background-color: #C19A6B;
+}
+
+.menu-item {
+    -fx-background-color: #C19A6B;
+}
+
+.menu-item:hover {
+    -fx-background-color: #F5DEB3;
+}
+
+.menu-item:armed {
+    -fx-background-color: #F5DEB3;
 }
 
 /*
@@ -218,27 +239,27 @@
  */
 .button {
     -fx-padding: 5 22 5 22;
-    -fx-border-color: #e2e2e2;
+    -fx-border-color: #C2A57A;
     -fx-border-width: 2;
     -fx-background-radius: 0;
-    -fx-background-color: #1d1d1d;
+    -fx-background-color: #FFEFD5;
     -fx-font-family: "Segoe UI", Helvetica, Arial, sans-serif;
     -fx-font-size: 11pt;
-    -fx-text-fill: #d8d8d8;
+    -fx-text-fill: #3E2F1C;
     -fx-background-insets: 0 0 0 0, 0, 1, 2;
 }
 
 .button:hover {
-    -fx-background-color: #3a3a3a;
+    -fx-background-color: #F5DEB3;
 }
 
 .button:pressed, .button:default:hover:pressed {
-  -fx-background-color: white;
-  -fx-text-fill: #1d1d1d;
+  -fx-background-color: #C19A6B;
+  -fx-text-fill: white;
 }
 
 .button:focused {
-    -fx-border-color: white, white;
+    -fx-border-color: #C19A6B, #C19A6B;
     -fx-border-width: 1, 1;
     -fx-border-style: solid, segments(1, 1);
     -fx-border-radius: 0, 0;
@@ -247,50 +268,50 @@
 
 .button:disabled, .button:default:disabled {
     -fx-opacity: 0.4;
-    -fx-background-color: #1d1d1d;
-    -fx-text-fill: white;
+    -fx-background-color: #FFEFD5;
+    -fx-text-fill: #3E2F1C;
 }
 
 .button:default {
     -fx-background-color: -fx-focus-color;
-    -fx-text-fill: #ffffff;
+    -fx-text-fill: white;
 }
 
 .button:default:hover {
-    -fx-background-color: derive(-fx-focus-color, 30%);
+    -fx-background-color: derive(#C19A6B, 30%);
 }
 
 .dialog-pane {
-    -fx-background-color: #1d1d1d;
+    -fx-background-color: #FFEFD5;
 }
 
 .dialog-pane > *.button-bar > *.container {
-    -fx-background-color: #1d1d1d;
+    -fx-background-color: #FFEFD5;
 }
 
 .dialog-pane > *.label.content {
     -fx-font-size: 14px;
     -fx-font-weight: bold;
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
 }
 
 .dialog-pane:header *.header-panel {
-    -fx-background-color: derive(#1d1d1d, 25%);
+    -fx-background-color: derive(#FFEFD5, -15%);
 }
 
 .dialog-pane:header *.header-panel *.label {
     -fx-font-size: 18px;
     -fx-font-style: italic;
-    -fx-fill: white;
-    -fx-text-fill: white;
+    -fx-fill: #3E2F1C;
+    -fx-text-fill: #3E2F1C;
 }
 
 .scroll-bar {
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: derive(#FFEFD5, -10%);
 }
 
 .scroll-bar .thumb {
-    -fx-background-color: derive(#1d1d1d, 50%);
+    -fx-background-color: derive(#FFEFD5, -30%);
     -fx-background-insets: 3;
 }
 
@@ -318,18 +339,20 @@
 
 #commandTypeLabel {
     -fx-font-size: 11px;
-    -fx-text-fill: #F70D1A;
+    -fx-text-fill: #C94C4C;
 }
 
 #commandTextField {
-    -fx-background-color: transparent #383838 transparent #383838;
+    -fx-background-color: transparent #FFF5E6 transparent #FFF5E6;
     -fx-background-insets: 0;
-    -fx-border-color: #383838 #383838 #ffffff #383838;
+    -fx-border-color: #FFF5E6 #FFF5E6 #C19A6B #FFF5E6;
     -fx-border-insets: 0;
     -fx-border-width: 1;
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
-    -fx-text-fill: white;
+    -fx-text-fill: #3E2F1C;
+    -fx-prompt-text-fill: #A67B5B;    /* placeholder text colour */
+    -fx-font-weight: bold;
 }
 
 #filterField, #personListPanel, #personWebpage {
@@ -337,7 +360,7 @@
 }
 
 #resultDisplay .content {
-    -fx-background-color: transparent, #383838, transparent, #383838;
+    -fx-background-color: derive(#FFEFD5, -5%);
     -fx-background-radius: 0;
 }
 
@@ -347,10 +370,25 @@
 }
 
 #tags .label {
+    -fx-background-color: #C19A6B;
     -fx-text-fill: white;
-    -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+}
+
+.app-header {
+    -fx-background-color: #FFEFD5;
+    -fx-padding: 10 0 10 0;
+    -fx-border-color: #C19A6B;
+    -fx-border-width: 0 0 1 0;
+}
+
+.app-header-label {
+    -fx-font-size: 36pt;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: #3E2F1C;
+    -fx-font-weight: bold;
+    -fx-padding: 0 0 0 15; /* top, right, bottom, left */
 }


### PR DESCRIPTION
Close #138 

Add PapayaWhip theme to UI

<img width="1906" height="951" alt="Screenshot 2026-03-23 225305" src="https://github.com/user-attachments/assets/1db506da-1046-42d9-9769-a85a50c2313b" />

UI code is not my forte - has never been and never will be. Currently the menu items (eg. “Help F1") have a small strip of a darker shade (due to the padding), but it will do for now

<img width="598" height="265" alt="image" src="https://github.com/user-attachments/assets/66793204-2e20-47a4-898c-eb550456007b" />