### PR TITLE
Removed unused method in DeleteCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -72,14 +72,4 @@ public class DeleteCommand extends Command {
                 .add("targetId", targetId)
                 .toString();
     }
-
-    private String getInvalidIdMessage(int listSize) {
-        if (listSize == 0) {
-            return MESSAGE_EMPTY_CONTACT_LIST;
-        }
-        if (listSize == 1) {
-            return MESSAGE_SINGLE_CONTACT_ONLY;
-        }
-        return String.format(MESSAGE_INVALID_ID, listSize);
-    }
 }


### PR DESCRIPTION
close #112 
Since the index was previously updated to ID, the bug inside the issue no longer exist. Some methods are also unused now and such methods are now removed.