### PR TITLE
fix: Fix error message for EditCommand id overflow

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -360,7 +360,7 @@ These rules apply across multiple commands in EduConnect:
   * If the contact with the highest `ID` is deleted, that `ID` may be reused by the next added contact.
       * e.g., if the current highest `ID` is `10` and contact `9` is deleted, the next added contact will have `ID` `11`.
       * e.g., if contact `10` is deleted, the next added contact will reuse `ID` `10`.
-  * `ID` must be a positive integer (`1`, `2`, `3`, …).
+  * `ID` must be a positive integer that does not lead to overflow (`1`, `2`, `3`, …, `2,147,483,647`).
 
 * Empty values:
   * For `add`, providing an optional prefix with no value creates the contact with that field missing.<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -360,7 +360,7 @@ These rules apply across multiple commands in EduConnect:
   * If the contact with the highest `ID` is deleted, that `ID` may be reused by the next added contact.
       * e.g., if the current highest `ID` is `10` and contact `9` is deleted, the next added contact will have `ID` `11`.
       * e.g., if contact `10` is deleted, the next added contact will reuse `ID` `10`.
-  * `ID` must be a positive integer that does not lead to overflow (`1`, `2`, `3`, …, `2,147,483,647`).
+  * `ID` must be a positive integer that does not lead to an integer overflow (`1`, `2`, `3`, …, `2,147,483,647`).
 
 * Empty values:
   * For `add`, providing an optional prefix with no value creates the contact with that field missing.<br>

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -42,17 +42,18 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS, PREFIX_TIME,
-                        PREFIX_TAG, PREFIX_TAG_DELETE, PREFIX_REMARK, PREFIX_MEETING_LINK);
 
-        Id id;
-
-        try {
-            id = ParserUtil.parseId(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_ADDRESS, PREFIX_TIME, PREFIX_TAG,
+                PREFIX_TAG_DELETE, PREFIX_REMARK, PREFIX_MEETING_LINK);
+
+        Id id = ParserUtil.parseId(argMultimap.getPreamble());
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS, PREFIX_TIME,
                 PREFIX_REMARK, PREFIX_MEETING_LINK);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -72,7 +72,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_NAME_AMY, Id.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
 
@@ -87,10 +87,21 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidPreamble_failure() {
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        // non-positive id
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, Id.MESSAGE_CONSTRAINTS); // negative id
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, Id.MESSAGE_CONSTRAINTS); // zero id
+
+        // wrongly formatted id
+        assertParseFailure(parser, "1 some random string", Id.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1 i/ string", Id.MESSAGE_CONSTRAINTS);
+
+        // id leading to overflow
+        long maxPossibleInt = Integer.MAX_VALUE;
+        long minPossibleInt = Integer.MIN_VALUE;
+        assertParseFailure(parser, Long.toString(maxPossibleInt + 1),
+                Id.OVERFLOW_MESSAGE_CONSTRAINTS); // positive id
+        assertParseFailure(parser, Long.toString(minPossibleInt - 1),
+                Id.OVERFLOW_MESSAGE_CONSTRAINTS); // negative id
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -72,8 +72,12 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
-        assertParseFailure(parser, VALID_NAME_AMY, Id.MESSAGE_CONSTRAINTS);
+        // nothing provided alongside "edit" - invalid input format
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+
+        // id missing, only a string is provided alongside "edit"
+        // this string cannot be parsed into an id, so we treat it as an invalid id
+        assertParseFailure(parser, VALID_NAME_AMY, Id.MESSAGE_CONSTRAINTS);
     }
 
     @Test


### PR DESCRIPTION
Close #380 

For invalid ids, we give the corresponding error message, which has priority over the general "invalid edit command format" message

<img width="960" height="183" alt="image" src="https://github.com/user-attachments/assets/4e620c0d-7cf1-4c47-829f-e72db37b2505" />

<img width="1779" height="425" alt="image" src="https://github.com/user-attachments/assets/922ca6ab-adc6-4e66-a632-d784f24912a8" />

<img width="766" height="204" alt="image" src="https://github.com/user-attachments/assets/ae915224-7f60-4953-ac1f-657170562721" />

<img width="807" height="257" alt="image" src="https://github.com/user-attachments/assets/9c2622d9-af3a-4cd6-8a44-2c09d87e5799" />
