### PR TITLE
Reject zero-duration weekly timeslots

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -417,7 +417,7 @@ These rules apply across multiple commands in EduConnect:
     * time range: `Day HH:mm - HH:mm` or `Day HHmm - HHmm` (spaces around `-` are optional)
     * day must come before time (e.g. `d/tue 1500`, not `d/1500 tue`)
   * Valid weekdays: `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`.
-  * Valid time: 24-hour time (`00:00` to `23:59`). A duration must not end before it starts.
+  * Valid time: 24-hour time (`00:00` to `23:59`). A duration must end later than it starts.
   * Display is normalized (e.g. `monday 1800` → `Monday 18:00`).
   * Overlapping weekly timeslots across different contacts are allowed (e.g. staggered lessons for different students).
 

--- a/src/main/java/seedu/address/model/person/Time.java
+++ b/src/main/java/seedu/address/model/person/Time.java
@@ -21,7 +21,7 @@ public class Time {
                     + "Use: Day HH:mm, Day HHmm, Day HH:mm - HH:mm, or Day HHmm - HHmm.\n"
                     + "Day must begin with at least the first two letters of a valid day name.\n"
                     + "Time must use valid 24-hour values.\n"
-                    + "For durations, the end time must not be earlier than the start time.";
+                    + "For durations, the end time must be later than the start time.";
     private static final String EMPTY_STRING = "";
     private static final String DAY_TIME_SEPARATOR = " ";
     private static final String DURATION_SEPARATOR = " - ";
@@ -188,7 +188,7 @@ public class Time {
 
         LocalTime startTime = parseSingleTime(startTimeString);
         LocalTime endTime = parseSingleTime(endTimeString);
-        if (startTime == null || endTime == null || endTime.isBefore(startTime)) {
+        if (startTime == null || endTime == null || !endTime.isAfter(startTime)) {
             return null;
         }
 

--- a/src/test/java/seedu/address/model/person/TimeTest.java
+++ b/src/test/java/seedu/address/model/person/TimeTest.java
@@ -18,6 +18,7 @@ public class TimeTest {
     public void constructor_invalidTime_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new Time("25:00"));
         assertThrows(IllegalArgumentException.class, () -> new Time("18:00 - 17:30"));
+        assertThrows(IllegalArgumentException.class, () -> new Time("Monday 18:00 - 18:00"));
         assertThrows(IllegalArgumentException.class, () -> new Time("Monday"));
         assertThrows(IllegalArgumentException.class, () -> new Time("Funday 18:00"));
         assertThrows(IllegalArgumentException.class, () -> new Time("Monday 18:00 - 17:30"));
@@ -35,6 +36,7 @@ public class TimeTest {
         assertFalse(Time.isValidTime("9:30"));
         assertFalse(Time.isValidTime("093"));
         assertFalse(Time.isValidTime("18:00 - 17:30"));
+        assertFalse(Time.isValidTime("Monday 18:00 - 18:00"));
         assertFalse(Time.isValidTime("18:00 - 1830"));
         assertFalse(Time.isValidTime("Monday"));
         assertFalse(Time.isValidTime("Funday 18:00"));


### PR DESCRIPTION
## Summary
- reject weekly timeslot ranges whose start and end times are identical
- align the user-facing validation wording with the tightened rule
- add regression coverage for zero-duration timeslots

## Root cause
The Time validator only rejected ranges whose end time was earlier than the start time, so equal start/end times were mistakenly accepted as valid durations.

## Testing
- ./gradlew test --tests seedu.address.model.person.TimeTest

Closes #341