### PR TITLE
Reject deletion of missing tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -134,7 +134,7 @@ Tag rules:
 * `t/TAG` adds tags; `tdel/TAG` removes tags.
 * Only valid tags may be used: `Student`, `Parent`, `Tutor` (case-insensitive).
 * For a given contact, adding a tag that already exists has no effect.
-* Similarly, deleting a tag that does not exist has no effect.
+* Deleting a tag that the contact does not have causes the command to fail.
 * To clear all tags, use `t/` by itself.
 * The same tag cannot be added and deleted in the same command.
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -90,6 +90,14 @@ public class EditCommand extends Command {
             throw new CommandException(Messages.MESSAGE_NOT_EDITED);
         }
 
+        Optional<Tag> missingTag = editPersonDescriptor.getTagsToDelete().stream()
+                .flatMap(Set::stream)
+                .filter(tag -> !personToEdit.getTags().contains(tag))
+                .findFirst();
+        if (missingTag.isPresent()) {
+            throw new CommandException(String.format(MESSAGE_MISSING_TAG_TO_DELETE, missingTag.get().tagName));
+        }
+
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
@@ -106,8 +114,7 @@ public class EditCommand extends Command {
      * existing tags, specified deleted tags are removed, and an empty edited tag
      * set clears all tags.
      */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor)
-            throws CommandException {
+    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(personToEdit);
         requireNonNull(editPersonDescriptor);
 
@@ -134,8 +141,7 @@ public class EditCommand extends Command {
                 updatedRemark, updatedMeetingLink);
     }
 
-    private static Set<Tag> createUpdatedTags(Set<Tag> existingTags, EditPersonDescriptor editPersonDescriptor)
-            throws CommandException {
+    private static Set<Tag> createUpdatedTags(Set<Tag> existingTags, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(existingTags);
         requireNonNull(editPersonDescriptor);
 
@@ -143,11 +149,9 @@ public class EditCommand extends Command {
                 .map(tagsToApply -> mergeTags(existingTags, tagsToApply))
                 .orElse(existingTags);
 
-        if (editPersonDescriptor.getTagsToDelete().isEmpty()) {
-            return tagsAfterAdditions;
-        }
-
-        return removeTags(tagsAfterAdditions, editPersonDescriptor.getTagsToDelete().get());
+        return editPersonDescriptor.getTagsToDelete()
+                .map(tagsToDelete -> removeTags(tagsAfterAdditions, tagsToDelete))
+                .orElse(tagsAfterAdditions);
     }
 
     private static Set<Tag> mergeTags(Set<Tag> existingTags, Set<Tag> tagsToApply) {
@@ -163,16 +167,9 @@ public class EditCommand extends Command {
         return combinedTags;
     }
 
-    private static Set<Tag> removeTags(Set<Tag> existingTags, Set<Tag> tagsToDelete) throws CommandException {
+    private static Set<Tag> removeTags(Set<Tag> existingTags, Set<Tag> tagsToDelete) {
         requireNonNull(existingTags);
         requireNonNull(tagsToDelete);
-
-        Optional<Tag> missingTag = tagsToDelete.stream()
-                .filter(tag -> !existingTags.contains(tag))
-                .findFirst();
-        if (missingTag.isPresent()) {
-            throw new CommandException(String.format(MESSAGE_MISSING_TAG_TO_DELETE, missingTag.get().tagName));
-        }
 
         Set<Tag> remainingTags = new HashSet<>(existingTags);
         remainingTags.removeAll(tagsToDelete);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -61,6 +61,8 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_SUCCESS =
             "Alright, the contact with ID %d has been edited to the following:";
+    public static final String MESSAGE_MISSING_TAG_TO_DELETE =
+            "This contact does not have the tag %s.";
 
     private final Id id;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -104,7 +106,8 @@ public class EditCommand extends Command {
      * existing tags, specified deleted tags are removed, and an empty edited tag
      * set clears all tags.
      */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor)
+            throws CommandException {
         requireNonNull(personToEdit);
         requireNonNull(editPersonDescriptor);
 
@@ -131,7 +134,8 @@ public class EditCommand extends Command {
                 updatedRemark, updatedMeetingLink);
     }
 
-    private static Set<Tag> createUpdatedTags(Set<Tag> existingTags, EditPersonDescriptor editPersonDescriptor) {
+    private static Set<Tag> createUpdatedTags(Set<Tag> existingTags, EditPersonDescriptor editPersonDescriptor)
+            throws CommandException {
         requireNonNull(existingTags);
         requireNonNull(editPersonDescriptor);
 
@@ -139,9 +143,11 @@ public class EditCommand extends Command {
                 .map(tagsToApply -> mergeTags(existingTags, tagsToApply))
                 .orElse(existingTags);
 
-        return editPersonDescriptor.getTagsToDelete()
-                .map(tagsToDelete -> removeTags(tagsAfterAdditions, tagsToDelete))
-                .orElse(tagsAfterAdditions);
+        if (editPersonDescriptor.getTagsToDelete().isEmpty()) {
+            return tagsAfterAdditions;
+        }
+
+        return removeTags(tagsAfterAdditions, editPersonDescriptor.getTagsToDelete().get());
     }
 
     private static Set<Tag> mergeTags(Set<Tag> existingTags, Set<Tag> tagsToApply) {
@@ -157,9 +163,16 @@ public class EditCommand extends Command {
         return combinedTags;
     }
 
-    private static Set<Tag> removeTags(Set<Tag> existingTags, Set<Tag> tagsToDelete) {
+    private static Set<Tag> removeTags(Set<Tag> existingTags, Set<Tag> tagsToDelete) throws CommandException {
         requireNonNull(existingTags);
         requireNonNull(tagsToDelete);
+
+        Optional<Tag> missingTag = tagsToDelete.stream()
+                .filter(tag -> !existingTags.contains(tag))
+                .findFirst();
+        if (missingTag.isPresent()) {
+            throw new CommandException(String.format(MESSAGE_MISSING_TAG_TO_DELETE, missingTag.get().tagName));
+        }
 
         Set<Tag> remainingTags = new HashSet<>(existingTags);
         remainingTags.removeAll(tagsToDelete);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -298,14 +298,14 @@ public class EditCommandTest {
                 createTagTestPerson(44, VALID_TAG_STUDENT, VALID_TAG_PARENT),
                 VALID_TAG_STUDENT);
         assertAddStudentDeleteParentSuccess(
-                createTagTestPerson(45, VALID_TAG_STUDENT),
-                VALID_TAG_STUDENT);
-        assertAddStudentDeleteParentSuccess(
                 createTagTestPerson(46, VALID_TAG_PARENT),
                 VALID_TAG_STUDENT);
-        assertAddStudentDeleteParentSuccess(
-                createTagTestPerson(47),
-                VALID_TAG_STUDENT);
+    }
+
+    @Test
+    public void execute_addStudentDeleteMissingParent_failure() {
+        assertAddStudentDeleteParentFailure(createTagTestPerson(45, VALID_TAG_STUDENT));
+        assertAddStudentDeleteParentFailure(createTagTestPerson(47));
     }
 
     @Test
@@ -352,21 +352,12 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_idInAddressBookDeleteMissingTag_success() {
+    public void execute_idInAddressBookDeleteMissingTag_failure() {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTagsToDelete(VALID_TAG_PARENT).build();
         EditCommand editCommand = new EditCommand(ID_FIRST, descriptor);
 
-        Optional<Person> personToEditFound = model.findPersonById(ID_FIRST);
-        assertTrue(personToEditFound.isPresent());
-        Person personToEdit = personToEditFound.get();
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS,
-                ID_FIRST.getValue());
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(personToEdit, personToEdit);
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(editCommand, model,
+                String.format(EditCommand.MESSAGE_MISSING_TAG_TO_DELETE, VALID_TAG_PARENT));
     }
 
     @Test
@@ -586,6 +577,23 @@ public class EditCommandTest {
         expectedModel.setPerson(personToEdit, editedPerson);
 
         assertCommandSuccess(editCommand, modelWithPerson, expectedMessage, expectedModel);
+    }
+
+    private void assertAddStudentDeleteParentFailure(Person personToEdit) {
+        AddressBook addressBook = new AddressBook();
+        addressBook.addPerson(personToEdit);
+        Model modelWithPerson = new ModelManager(addressBook, new UserPrefs());
+
+        Id personToEditId = personToEdit.getId();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withTags(VALID_TAG_STUDENT)
+                .withTagsToDelete(VALID_TAG_PARENT)
+                .build();
+        EditCommand editCommand = new EditCommand(personToEditId, descriptor);
+
+        assertCommandFailure(editCommand, modelWithPerson,
+                String.format(EditCommand.MESSAGE_MISSING_TAG_TO_DELETE, VALID_TAG_PARENT));
     }
 
     private Person createTagTestPerson(int id, String... tags) {


### PR DESCRIPTION
Closes #317

## What changed
- reject `edit ... tdel/...` when the contact does not currently have one of the requested tags to delete
- added a command message for missing tag deletions
- updated the edit command tests for the new behavior
- updated the User Guide tag rule to match the fix

## Why
- deleting a nonexistent tag previously reported success even though the requested tag removal did not happen

## Testing
- `./gradlew test --tests seedu.address.logic.commands.EditCommandTest`