### PR TITLE
Support overnight weekly timeslots

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -418,7 +418,7 @@ These rules apply across multiple commands in EduConnect:
     * time range: `Day HH:mm - HH:mm` or `Day HHmm - HHmm` (spaces around `-` are optional)
     * day must come before time (e.g. `d/tue 1500`, not `d/1500 tue`)
   * Valid weekdays: `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`.
-  * Valid time: 24-hour time (`00:00` to `23:59`). A duration must not end before it starts.
+  * Valid time: 24-hour time (`00:00` to `23:59`). If a duration ends earlier than or at the same time it starts, it continues into the next day.
   * Display is normalized (e.g. `monday 1800` → `Monday 18:00`).
   * Overlapping weekly timeslots across different contacts are allowed (e.g. staggered lessons for different students).
 

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -168,7 +168,16 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
 
-        return durationParts[0].compareTo(time) <= 0 && time.compareTo(durationParts[1]) <= 0;
+        int timeMinute = getMinuteOfDay(time);
+        int startMinute = getMinuteOfDay(durationParts[0]);
+        int endMinute = getMinuteOfDay(durationParts[1]);
+        return startMinute < endMinute
+                ? startMinute <= timeMinute && timeMinute <= endMinute
+                : timeMinute >= startMinute || timeMinute <= endMinute;
+    }
+
+    private int getMinuteOfDay(String time) {
+        return Integer.parseInt(time.substring(0, 2)) * 60 + Integer.parseInt(time.substring(3));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Time.java
+++ b/src/main/java/seedu/address/model/person/Time.java
@@ -21,7 +21,7 @@ public class Time {
                     + "Use: Day HH:mm, Day HHmm, Day HH:mm - HH:mm, or Day HHmm - HHmm.\n"
                     + "Day must begin with at least the first two letters of a valid day name.\n"
                     + "Time must use valid 24-hour values.\n"
-                    + "For durations, the end time must not be earlier than the start time.";
+                    + "For durations, an end time earlier than or equal to the start time continues into the next day.";
     private static final String EMPTY_STRING = "";
     private static final String DAY_TIME_SEPARATOR = " ";
     private static final String DURATION_SEPARATOR = " - ";
@@ -188,7 +188,7 @@ public class Time {
 
         LocalTime startTime = parseSingleTime(startTimeString);
         LocalTime endTime = parseSingleTime(endTimeString);
-        if (startTime == null || endTime == null || endTime.isBefore(startTime)) {
+        if (startTime == null || endTime == null) {
             return null;
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -86,8 +86,8 @@ public class CommandTestUtil {
     // not a valid hour
     public static final String INVALID_TIME_DESC = " " + PREFIX_TIME + "Monday 25:00";
 
-    // duration going backwards in time
-    public static final String INVALID_TIME_DURATION_DESC = " " + PREFIX_TIME + "Monday 18:00 - 17:30";
+    // mixed duration formats are not allowed
+    public static final String INVALID_TIME_DURATION_DESC = " " + PREFIX_TIME + "Monday 18:00 - 1730";
 
     // no day in time provided
     public static final String INVALID_TIME_NO_DAY_DESC = " " + PREFIX_TIME + "1800";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -84,6 +84,16 @@ public class AddCommandParserTest {
     }
 
     @Test
+    public void parse_overnightTime_success() {
+        Person expectedPerson = new PersonBuilder(AMY).withTime("Wednesday 23:00 - 01:00").build();
+
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY
+                + ADDRESS_DESC_AMY + " " + PREFIX_TIME + "Wed 2300-0100"
+                + TAG_DESC_STUDENT + REMARK_DESC_AMY + MEETING_LINK_DESC_AMY,
+                new AddCommand(expectedPerson));
+    }
+
+    @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB
                 + ADDRESS_DESC_BOB + TIME_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -407,4 +407,16 @@ public class EditCommandParserTest {
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
+
+    @Test
+    public void parse_overnightDurationTimeFormat_success() {
+        Id targetId = ID_SECOND;
+        String userInput = targetId.getValue() + " " + PREFIX_TIME + "Wed 2300-0100";
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withTime("Wednesday 23:00 - 01:00").build();
+        EditCommand expectedCommand = new EditCommand(targetId, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -324,6 +324,10 @@ public class FindCommandParserTest {
 
         assertParseSuccess(parser, " " + PREFIX_TIME + "fRi 1500-1600",
                 expectedTimeFindCommand(List.of(new TimeSearchKeyword("Friday", "15:00 - 16:00")), MatchMode.OR));
+
+        assertParseSuccess(parser, " " + PREFIX_TIME + "Wed 2300-0100",
+                expectedTimeFindCommand(List.of(new TimeSearchKeyword("Wednesday", "23:00 - 01:00")),
+                        MatchMode.OR));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -39,6 +39,7 @@ public class ParserUtilTest {
     private static final String VALID_TIME_ALTERNATE = "monday 1800";
     private static final String VALID_TIME_DURATION = "Wednesday 18:00 - 19:30";
     private static final String VALID_TIME_DURATION_ALTERNATE = "wednesday 1800 - 1930";
+    private static final String VALID_TIME_OVERNIGHT_DURATION = "Wednesday 23:00 - 01:00";
     private static final String VALID_TAG_1 = "Student";
     private static final String VALID_TAG_2 = "Parent";
 
@@ -227,6 +228,12 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTime_validOvernightDuration_returnsTime() throws Exception {
+        Optional<Time> expectedTime = Optional.of(new Time(VALID_TIME_OVERNIGHT_DURATION));
+        assertEquals(expectedTime, ParserUtil.parseTime(Optional.of("wed 2300 - 0100")));
+    }
+
+    @Test
     public void parseTime_emptyOptional_returnsEmptyOptional() throws Exception {
         assertEquals(Optional.empty(), ParserUtil.parseTime(Optional.empty()));
     }
@@ -243,8 +250,20 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseFindTimeKeyword_invalidMixedRange_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseFindTimeKeyword("Mon 1700-16:00"));
+    public void parseFindTimeKeyword_validOvernightRange_returnsTimeSearchKeyword() throws Exception {
+        assertEquals(new TimeSearchKeyword("Wednesday", "23:00 - 01:00"),
+                ParserUtil.parseFindTimeKeyword("wed 2300-0100"));
+    }
+
+    @Test
+    public void parseFindTimeKeyword_validMixedOvernightRange_returnsTimeSearchKeyword() throws Exception {
+        assertEquals(new TimeSearchKeyword("Monday", "17:00 - 16:00"),
+                ParserUtil.parseFindTimeKeyword("Mon 1700-16:00"));
+    }
+
+    @Test
+    public void parseFindTimeKeyword_invalidRange_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseFindTimeKeyword("Mon 1700-160"));
         assertThrows(ParseException.class, () -> ParserUtil.parseFindTimeKeyword("Mon 1700-aaaa"));
     }
 

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -479,6 +479,30 @@ public class PersonContainsKeywordsPredicateTest {
     }
 
     @Test
+    public void test_timeKeywords_overnightStoredTimeBehavesAsExpected() {
+        Person overnightDuration = new PersonBuilder().withTime("Wednesday 23:00 - 01:00").build();
+
+        PersonContainsKeywordsPredicate predicate = predicateWithDateTimeKeywords(
+                List.of(new TimeSearchKeyword("", "00:30")), MatchMode.OR);
+        assertTrue(predicate.test(overnightDuration));
+
+        predicate = predicateWithDateTimeKeywords(List.of(new TimeSearchKeyword("", "01:30")), MatchMode.OR);
+        assertFalse(predicate.test(overnightDuration));
+    }
+
+    @Test
+    public void test_timeKeywords_fullDayStoredTimeBehavesAsExpected() {
+        Person fullDayDuration = new PersonBuilder().withTime("Wednesday 16:00 - 16:00").build();
+
+        PersonContainsKeywordsPredicate predicate = predicateWithDateTimeKeywords(
+                List.of(new TimeSearchKeyword("", "15:59")), MatchMode.OR);
+        assertTrue(predicate.test(fullDayDuration));
+
+        predicate = predicateWithDateTimeKeywords(List.of(new TimeSearchKeyword("", "16:01")), MatchMode.OR);
+        assertTrue(predicate.test(fullDayDuration));
+    }
+
+    @Test
     public void test_noTime_false() {
         PersonContainsKeywordsPredicate predicate = predicateWithDateTimeKeywords(
                 List.of(new TimeSearchKeyword("Wednesday", "15:00")), MatchMode.OR);

--- a/src/test/java/seedu/address/model/person/TimeTest.java
+++ b/src/test/java/seedu/address/model/person/TimeTest.java
@@ -20,7 +20,7 @@ public class TimeTest {
         assertThrows(IllegalArgumentException.class, () -> new Time("18:00 - 17:30"));
         assertThrows(IllegalArgumentException.class, () -> new Time("Monday"));
         assertThrows(IllegalArgumentException.class, () -> new Time("Funday 18:00"));
-        assertThrows(IllegalArgumentException.class, () -> new Time("Monday 18:00 - 17:30"));
+        assertThrows(IllegalArgumentException.class, () -> new Time("Monday 18:00 - 1830"));
     }
 
     @Test
@@ -52,6 +52,8 @@ public class TimeTest {
         assertTrue(Time.isValidTime("thu 08:15 - 09:45"));
         assertTrue(Time.isValidTime("Sunday 18:00 - 19:30"));
         assertTrue(Time.isValidTime("sunday 1800 - 1930"));
+        assertTrue(Time.isValidTime("Monday 18:00 - 17:30"));
+        assertTrue(Time.isValidTime("Wednesday 1600 - 1600"));
     }
 
     @Test
@@ -76,6 +78,8 @@ public class TimeTest {
         assertEquals("Thursday 08:15 - 09:45", new Time("thu 08:15 - 09:45").value);
         assertEquals("Sunday 18:00 - 19:30", new Time("Sunday 18:00 - 19:30").value);
         assertEquals("Sunday 18:00 - 19:30", new Time("sunday 1800 - 1930").value);
+        assertEquals("Monday 18:00 - 17:30", new Time("Monday 18:00 - 17:30").value);
+        assertEquals("Wednesday 16:00 - 16:00", new Time("Wednesday 1600 - 1600").value);
     }
 
     @Test
@@ -95,6 +99,7 @@ public class TimeTest {
     public void fromStoredValue_legacyTime_returnsCanonicalLegacyValue() {
         assertEquals("18:00", Time.fromStoredValue("1800").value);
         assertEquals("18:00 - 19:30", Time.fromStoredValue("18:00 - 19:30").value);
+        assertEquals("18:00 - 17:30", Time.fromStoredValue("18:00 - 17:30").value);
     }
 
     @Test


### PR DESCRIPTION
Closes #319
Closes #320
Closes #341

## What changed
- removed the same-day-only duration restriction for weekly timeslots
- durations whose end time is earlier than or equal to the start time are now interpreted as continuing into the next day
- kept canonical storage and display format unchanged
- updated parsing tests for `add`, `edit`, and `find` time queries
- updated time matching so time-only `find d/...` queries work with overnight and full-day durations
- updated the User Guide wording for weekly timeslot durations

## Why
- the reported bugs all came from treating end-before-start and end-equals-start durations as invalid, even though both are meaningful weekly timeslots

## Testing
- `./gradlew test --tests seedu.address.model.person.TimeTest --tests seedu.address.logic.parser.ParserUtilTest --tests seedu.address.logic.parser.AddCommandParserTest --tests seedu.address.logic.parser.EditCommandParserTest --tests seedu.address.logic.parser.FindCommandParserTest --tests seedu.address.model.person.PersonContainsKeywordsPredicateTest`

## Scope note
- this PR does not close #360 because it does not add support for multiple weekly timeslots per contact